### PR TITLE
2023.04.05.03

### DIFF
--- a/WME-URComments-Enhanced.js
+++ b/WME-URComments-Enhanced.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        WME URComments-Enhanced (beta)
 // @namespace   https://greasyfork.org/users/166843
-// @version     2023.04.05.02
+// @version     2023.04.05.03
 // eslint-disable-next-line max-len
 // @description URComments-Enhanced (URC-E) allows Waze editors to handle WME update requests more quickly and efficiently. Also adds many UR filtering options, ability to change the markers, plus much, much, more!
 // @grant       GM_xmlhttpRequest
@@ -2811,7 +2811,7 @@
                             urceData.fullText += `${urSessionsObj.comments[commentIdx].text} `;
                             urceData.commentUserIds.push(urSessionsObj.comments[commentIdx].userID);
                         }
-                        if (/\[\s*\S+[\s\S]+\]/m.test(urceData.fullText))
+                        if (/\[\s*\S+[\s\S]*\]/m.test(urceData.fullText))
                             urceData.containsSquareBrackets = true;
                         if (urceData.commentUserIds.indexOf(_wmeUserId) > -1)
                             urceData.commentsByMe = true;


### PR DESCRIPTION
NEW: Check for updated version on load.
BUGFIX: Issues when Issue Tracker has greater than 499 URs.
BUGFIX: UR Panel showed -1 for urId in certain situations.
BUGFIX: Save button observer in WME beta.
BUGFIX: Restore settings resulted in error before completion.
CHANGE: Moved urceData to private object instead of WME model.
CHANGE: "Enable UR Overflow" no longer applies if zoom level is less than 10.
CHANGE: Auto-send reminder comment will no longer send if zoom level is less than 10.
CHANGE: Miscellaneous code variable changes.
CHANGE: Issue tracker bugfix also resulted in necessity to disable auto refresh setting.
CHANGE: Future (possible) WME changes preparation. (fixed)