### PR TITLE
Make script work for safari

### DIFF
--- a/WME-URComments-Enhanced.js
+++ b/WME-URComments-Enhanced.js
@@ -343,7 +343,7 @@
             headers,
             onload(res) {
                 if (shouldFallback(res)) {
-                    fetchFallback(res, onload);
+                    fetchFallback(res, onerror);
                     return;
                 }
                 onload(res);

--- a/WME-URComments-Enhanced.js
+++ b/WME-URComments-Enhanced.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name        WME URComments-Enhanced
 // @namespace   https://greasyfork.org/users/166843
-// @version     2025.12.09.01
+// @version     2026.04.01.01
 // eslint-disable-next-line max-len
 // @description URComments-Enhanced (URC-E) allows Waze editors to handle WME update requests more quickly and efficiently. Also adds many UR filtering options, ability to change the markers, plus much, much, more!
 // @grant       GM_xmlhttpRequest
 // @match       *://*.waze.com/*editor*
 // @exclude     *://*.waze.com/user/editor*
-// @require     https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
+// @require     https://update.greasyfork.org/scripts/24851/WazeWrap.js
 // @author      dBsooner
 // @license     MIT/BSD/X11
 // @connect     greasyfork.org
@@ -275,6 +275,83 @@
     function logDebug(message, data = '') {
         if (_DEBUG)
             log(message, data);
+    }
+
+    function formatXhrError(res, label = 'Request error') {
+        if (!res)
+            return label;
+        const details = [];
+        if (typeof res.status !== 'undefined')
+            details.push(`status ${res.status}`);
+        if (res.statusText)
+            details.push(res.statusText);
+        if (res.finalUrl)
+            details.push(res.finalUrl);
+        if (res.responseText) {
+            try {
+                const parsed = JSON.parse(res.responseText);
+                if (parsed?.error?.message)
+                    details.push(parsed.error.message);
+            }
+            catch (e) {
+                // Ignore JSON parsing issues and keep collected request metadata only.
+            }
+        }
+        return `${label}${details.length > 0 ? `: ${details.join(' | ')}` : ''}`;
+    }
+
+    function requestWithReferrerFallback(options) {
+        const { url, method = 'GET', headers = {}, onload, onerror } = options;
+        const shouldFallback = (res) => {
+            const body = res?.responseText || '';
+            return (res?.status === 403) && (/referer\s*<empty>/i.test(body) || /requests from referer/i.test(body));
+        };
+        const fetchFallback = async (originalRes, routeTo) => {
+            try {
+                const pageWindow = (typeof unsafeWindow !== 'undefined') ? unsafeWindow : window;
+                // Referer is a forbidden header in fetch; use page context to inherit normal browser referrer behavior.
+                const safeHeaders = { ...headers };
+                delete safeHeaders.Referer;
+                delete safeHeaders.referer;
+                const response = await pageWindow.fetch(url, {
+                    method,
+                    headers: safeHeaders,
+                    credentials: 'omit'
+                });
+                const responseText = await response.text();
+                const fallbackRes = {
+                    status: response.status,
+                    statusText: response.statusText,
+                    responseText,
+                    finalUrl: response.url || url
+                };
+                onload(fallbackRes);
+            }
+            catch (fetchErr) {
+                const fallbackErr = {
+                    status: 0,
+                    statusText: fetchErr?.message || 'fetch failed',
+                    finalUrl: url,
+                    responseText: ''
+                };
+                routeTo(fallbackErr);
+            }
+        };
+        GM_xmlhttpRequest({
+            url,
+            method,
+            headers,
+            onload(res) {
+                if (shouldFallback(res)) {
+                    fetchFallback(res, onload);
+                    return;
+                }
+                onload(res);
+            },
+            onerror(res) {
+                fetchFallback(res, onerror);
+            }
+        });
     }
 
     function dynamicSort(property) {
@@ -4022,7 +4099,7 @@
             commentListIdx = (isNaN(commentListIdx)) ? _settings.commentList : commentListIdx;
             const commentListInfo = getCommentListInfo(commentListIdx);
             logDebug(`Beginning comment list async for comment list: ${commentListInfo.name}`);
-            GM_xmlhttpRequest({
+            requestWithReferrerFallback({
                 url: `https://sheets.googleapis.com/v4/spreadsheets/${((commentListIdx === 1001) ? _settings.customSsId : dec(_URCE_SPREADSHEET_ID))}/values/${commentListInfo.gSheetRange}?key=${dec(_URCE_API_KEY)}`,
                 headers: { 'Content-Type': 'application/json', Referer: 'https://www.waze.com' },
                 method: 'GET',
@@ -4407,8 +4484,19 @@
 
     function handleError(err) {
         const divElemRoot = createElem('div', { class: 'URCE-divLoading' });
-        if (err.message?.includes('|') > -1) {
-            const [reason, version] = err.message.split('|');
+        let errMessage = (typeof err === 'string') ? err : (err?.message || '');
+        if (!errMessage && (typeof err === 'object')) {
+            try {
+                errMessage = JSON.stringify(err);
+            }
+            catch (e) {
+                errMessage = String(err);
+            }
+        }
+        if (errMessage === '[object Object]')
+            errMessage = formatXhrError(err, 'Unexpected error');
+        if (errMessage.includes('|')) {
+            const [reason, version] = errMessage.split('|');
             if ((reason === 'updateRequired') || (reason === 'spreadsheetUpdateRequired')) {
                 const scriptLink = createElem('a', {
                         href: _IS_BETA_VERSION ? dec(_BETA_DL_URL) : _PROD_DL_URL, target: '_blank', textContent: _IS_BETA_VERSION ? dec(_BETA_DL_URL) : _PROD_DL_URL
@@ -4427,6 +4515,10 @@
         }
         else {
             divElemRoot.appendChild(createElem('div', { textContent: (err.commentList === 1001) ? I18n.t('urce.prompts.CustomGSheetLoadError') : I18n.t('urce.common.ErrorGeneric') }));
+            if (errMessage.length > 0) {
+                divElemRoot.appendChild(createElem('br'));
+                divElemRoot.appendChild(createElem('div', { textContent: `Details: ${errMessage}` }));
+            }
         }
         logError(divElemRoot.textContent);
         _commentListLoaded = false;
@@ -5815,7 +5907,7 @@
                     resolve();
                 }
             };
-            GM_xmlhttpRequest({
+            requestWithReferrerFallback({
                 url: `https://sheets.googleapis.com/v4/spreadsheets/${dec(_URCE_SPREADSHEET_ID)}/values/CommentLists!A3:G?key=${dec(_URCE_API_KEY)}`,
                 headers: { 'Content-Type': 'application/json', Referer: 'https://www.waze.com' },
                 method: 'GET',
@@ -5868,12 +5960,12 @@
                         }
                     }
                     else {
-                        errorText = errorText || res;
+                        errorText = errorText || formatXhrError(res, 'Comment list request failed');
                     }
                     postProcess(errorText);
                 },
                 onerror(res) {
-                    postProcess(`xmlhttpRequest error: ${JSON.stringify(res)}`);
+                    postProcess(formatXhrError(res, 'Comment list request failed'));
                 }
             });
         });
@@ -5883,12 +5975,11 @@
         return new Promise((resolve, reject) => {
             logDebug('Initializing auto switch setup.');
             const postProcess = function (errorText) {
-                if (!errorText || (errorText && _STATIC_ONLY_USERS.includes(W.loginManager.user.getUsername())))
-                    resolve();
-                else
-                    reject(new Error(errorText));
+                if (errorText)
+                    logWarning(`Auto-switch setup unavailable: ${errorText}`);
+                resolve();
             };
-            GM_xmlhttpRequest({
+            requestWithReferrerFallback({
                 url: `https://sheets.googleapis.com/v4/spreadsheets/${dec(_URCE_SPREADSHEET_ID)}/values/CommentLists_AutoSwitch!A3:ZZ?majorDimension=COLUMNS&key=${dec(_URCE_API_KEY)}`,
                 headers: { 'Content-Type': 'application/json', Referer: 'https://www.waze.com' },
                 method: 'GET',
@@ -5927,12 +6018,12 @@
                         }
                     }
                     else {
-                        errorText = errorText || res;
+                        errorText = errorText || formatXhrError(res, 'Auto-switch request failed');
                     }
                     postProcess(errorText);
                 },
                 onerror(res) {
-                    postProcess(`xmlhttpRequest error: ${JSON.stringify(res)}`);
+                    postProcess(formatXhrError(res, 'Auto-switch request failed'));
                 }
             });
         });
@@ -5942,12 +6033,11 @@
         return new Promise((resolve, reject) => {
             logDebug('Initializing restrictions.');
             const postProcess = function (errorText) {
-                if (!errorText || (errorText && _STATIC_ONLY_USERS.includes(W.loginManager.user.getUsername())))
-                    resolve();
-                else
-                    reject(new Error(errorText));
+                if (errorText)
+                    logWarning(`Restrictions setup unavailable: ${errorText}`);
+                resolve();
             };
-            GM_xmlhttpRequest({
+            requestWithReferrerFallback({
                 url: `https://sheets.googleapis.com/v4/spreadsheets/${dec(_URCE_SPREADSHEET_ID)}/values/Restrictions!A3:ZZ?majorDimension=COLUMNS&key=${dec(_URCE_API_KEY)}`,
                 headers: { 'Content-Type': 'application/json', Referer: 'https://www.waze.com' },
                 method: 'GET',
@@ -5996,12 +6086,12 @@
                         }
                     }
                     else {
-                        errorText = errorText || res;
+                        errorText = errorText || formatXhrError(res, 'Restrictions request failed');
                     }
                     postProcess(errorText);
                 },
                 onerror(res) {
-                    postProcess(`xmlhttpRequest error: ${JSON.stringify(res)}`);
+                    postProcess(formatXhrError(res, 'Restrictions request failed'));
                 }
             });
         });
@@ -6203,7 +6293,7 @@
                 });
             }
             /* END FIX */
-            GM_xmlhttpRequest({
+            requestWithReferrerFallback({
                 url: `https://sheets.googleapis.com/v4/spreadsheets/${dec(_URCE_SPREADSHEET_ID)}/values/Script_Translations!A3:AA?key=${dec(_URCE_API_KEY)}`,
                 headers: { 'Content-Type': 'application/json', Referer: 'https://www.waze.com' },
                 method: 'GET',
@@ -6774,12 +6864,12 @@
                             _needTranslation = true;
                     }
                     else {
-                        errorText = errorText || res;
+                        errorText = errorText || formatXhrError(res, 'Translations request failed');
                     }
                     postProcess(errorText);
                 },
                 onerror(res) {
-                    postProcess(`xmlhttpRequest error: ${JSON.stringify(res)}`);
+                    postProcess(formatXhrError(res, 'Translations request failed'));
                 }
             });
         });

--- a/WME-URComments-Enhanced.js
+++ b/WME-URComments-Enhanced.js
@@ -334,7 +334,11 @@
                     finalUrl: url,
                     responseText: ''
                 };
-                routeTo(fallbackErr);
+                if (typeof onerror === 'function') {
+                    onerror(fallbackErr);
+                } else if (typeof routeTo === 'function') {
+                    routeTo(fallbackErr);
+                }
             }
         };
         GM_xmlhttpRequest({


### PR DESCRIPTION
## Summary
This PR improves Safari compatibility and startup reliability for URC-E by fixing Google Sheets request failures, improving fallback behavior, and making error diagnostics actionable instead of generic.

## Problem
On Safari, Google Sheets API calls were intermittently failing with 403 errors due to blocked requests from referer `<empty>`.

### This caused:
- startup warnings for auto-switch and restrictions data
- generic or blank error popups
- difficult troubleshooting due to low-quality error output

## What changed
- Updated userscript metadata:
  - switched WazeWrap require URL to update.greasyfork.org endpoint
  - Added request error normalization helper:
  - formats request failures with status, status text, URL, and parsed API error message when available
- Added Google Sheets transport fallback:
   - primary path remains GM_xmlhttpRequest
   - when Safari-style referer-blocked 403 is detected, retries via page-context fetch
   - strips forbidden Referer header before fetch retry
- Improved initialization resilience:
    - auto-switch and restrictions startup loaders now fail open with warnings instead of failing initialization
- Improved error reporting:
    - fixed error parsing condition in handleError
    - includes Details text in generic error popup when available
     - avoids Details: [object Object] by serializing/normalizing object errors
     
## Why this approach
- Keeps existing behavior for browsers where GM_xmlhttpRequest works normally.
- Adds Safari-specific fallback only when required.
- Preserves core script functionality even when optional startup datasets are unavailable.
- Provides clearer diagnostics for maintainers and users.

## User impact
- Reduced startup failures on Safari.
- Fewer generic/blank error popups.
- Better warning and error messages for debugging.
- Comment list and translation loading become more robust under API/network edge cases.