### PR TITLE
fix: pass W.model to getAddress() function to properly retrieve Address after new WME Update

### DIFF
--- a/WME-URComments-Enhanced.js
+++ b/WME-URComments-Enhanced.js
@@ -1580,7 +1580,7 @@
                 for (let idx = 0, { length } = selFeatures; idx < length; idx++) {
                     if (selFeatures[idx].getType() === 'segment') {
                         if (selFeatures.length > 1) {
-                            const address = selFeatures[idx].getAddress();
+                            const address = selFeatures[idx].getAddress(W.model);
                             if (idx === 0) {
                                 street1Name = getStreetName(address);
                                 if (text.includes('$SELSEGS_WITH_CITY$'))
@@ -1593,7 +1593,7 @@
                             }
                         }
                         else {
-                            const address = selFeatures[idx].getAddress();
+                            const address = selFeatures[idx].getAddress(W.model);
                             street1Name = getStreetName(address);
                             if (text.includes('$SELSEGS_WITH_CITY$'))
                                 ({ cityName, inOrNear } = getCityName(address));
@@ -1829,8 +1829,8 @@
         }
         if (replaceVars && text.includes('$PLACE_ADDRESS$')) {
             const placeObj = W.selectionManager.getSelectedDataModelObjects()[0];
-            if ((placeObj?.type === 'venue') && placeObj.getAddress().format())
-                text = text.replaceAll('$PLACE_ADDRESS$', placeObj.getAddress().format());
+            if ((placeObj?.type === 'venue') && placeObj.getAddress(W.model).format())
+                text = text.replaceAll('$PLACE_ADDRESS$', placeObj.getAddress(W.model).format());
             else
                 WazeWrap.Alerts.error(_SCRIPT_SHORT_NAME, I18n.t('urce.prompts.PlaceAddressInsertError'));
         }

--- a/WME-URComments-Enhanced.js
+++ b/WME-URComments-Enhanced.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        WME URComments-Enhanced
 // @namespace   https://greasyfork.org/users/166843
-// @version     2026.04.19.01
+// @version     2026.04.19.02
 // eslint-disable-next-line max-len
 // @description URComments-Enhanced (URC-E) allows Waze editors to handle WME update requests more quickly and efficiently. Also adds many UR filtering options, ability to change the markers, plus much, much, more!
 // @grant       GM_xmlhttpRequest
@@ -86,7 +86,7 @@
         _BETA_DL_URL = 'YUhSMGNITTZMeTluY21WaGMzbG1iM0pyTG05eVp5OXpZM0pwY0hSekx6TTNOelEyTkMxM2JXVXRkWEpqYjIxdFpXNTBjeTFsYm1oaGJtTmxaQzFpWlhSaEwyTnZaR1V2VjAxRkxWVlNRMjl0YldWdWRITXRSVzVvWVc1alpXUXVkWE5sY2k1cWN3PT0=',
         _ALERT_UPDATE = true,
         _SCRIPT_VERSION = GM_info.script.version.toString(),
-        _SCRIPT_VERSION_CHANGES = ['CHANGE: Latest WazeWrap release compatibility.'],
+        _SCRIPT_VERSION_CHANGES = ['FIX: Latest WME release compatibility.'],
         _MIN_VERSION_AUTOSWITCH = '2019.01.11.01',
         _MIN_VERSION_COMMENTLISTS = '2018.01.01.01',
         _MIN_VERSION_COMMENTS = '2019.03.01.01',


### PR DESCRIPTION
After the latest WME Update (2.348-7), the .getAddress() function now expects the W.model parameter.

This fixes the street/place address autocompletion in the UR message.